### PR TITLE
feat: actualizar versiones de dependencias #16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.1</version>
+        <version>3.4.2</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>ar.edu</groupId>
@@ -15,7 +15,7 @@
     <description>Spring Boot Facturacion Electronica</description>
     <properties>
         <java.version>21</java.version>
-        <kotlin.version>2.1.0</kotlin.version>
+        <kotlin.version>2.1.10</kotlin.version>
         <spring-cloud.version>2024.0.0</spring-cloud.version>
     </properties>
     <dependencies>
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.8.4</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
- Spring Boot: 3.4.1 → 3.4.2
- Kotlin: 2.1.0 → 2.1.10
- SpringDoc OpenAPI: 2.7.0 → 2.8.4

Las actualizaciones incluyen mejoras de seguridad y rendimiento. Pruebas ejecutadas satisfactoriamente.

Closes #16