### PR TITLE
docs: actualizar dependencias y mejorar documentación #20

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ Servicio de generación de reportes y documentos para UM Tesorería. Este micros
 ## Tecnologías
 
 - Java 21
-- Spring Boot 3.4.2
+- Spring Boot 3.4.3
 - Kotlin 2.1.10
 - OpenPDF 2.0.3
 - ZXing (para códigos QR)
 - Spring Cloud 2024.0.0
+- Caffeine (para caché)
 
 ## Documentación
 
@@ -54,7 +55,7 @@ mvn clean install
 mvn spring-boot:run
 ```
 
-El servicio estará disponible en `http://localhost:8080`
+El servicio estará disponible en `http://localhost:8080/swagger-ui.html` donde podrás consultar la documentación de la API
 
 ## Contribución
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.2</version>
+        <version>3.4.3</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>ar.edu</groupId>
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.8.4</version>
+            <version>2.8.5</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
- Spring Boot: 3.4.2 → 3.4.3
- SpringDoc OpenAPI: 2.8.4 → 2.8.5
- Agregar Caffeine a la lista de tecnologías
- Actualizar URL de acceso al Swagger UI
- Mejorar documentación de acceso al servicio

Closes #20