### PR TITLE
feat(reports): añade generación de planilla de pagos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0] - 2025-08-18
+### Added
+- **feat:** Se añade la funcionalidad para generar una planilla de pagos, incluyendo un nuevo endpoint y los clientes Feign necesarios (`ChequeraPagoClient`, `FacultadClient`, `TipoChequeraClient`).
+### Changed
+- **refactor:** Se estandariza la configuración de todos los clientes Feign para mejorar la legibilidad y prevenir conflictos.
+- **chore:** Se actualiza la dependencia de Spring Boot a la versión `3.5.4`.
+### Fixed
+- **fix:** Se corrigen los permisos de usuario en el `Dockerfile` para el directorio de la aplicación.
+
+---
 ## [0.0.1-SNAPSHOT] - 2025-05-31
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ WORKDIR /app
 # Copiamos el JAR generado desde la etapa de compilación
 COPY --from=build /app/target/um.tesoreria.report-service.jar ./um.tesoreria.report-service.jar
 
+# Damos permisos al usuario sobre el directorio de la aplicación
+RUN chown -R appuser:appgroup /app
+
 # Cambiamos al usuario no privilegiado
 USER appuser
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.3</version>
+        <version>3.5.4</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.report</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.1.0</version>
     <name>UM.tesoreria.report-service</name>
     <description>Spring Boot Report Service</description>
     <properties>

--- a/src/main/java/um/tesoreria/report/client/core/ChequeraCuotaClient.java
+++ b/src/main/java/um/tesoreria/report/client/core/ChequeraCuotaClient.java
@@ -7,7 +7,7 @@ import um.tesoreria.report.domain.dto.core.CuotaPeriodoDto;
 
 import java.util.List;
 
-@FeignClient(name = "tesoreria-core-service/api/tesoreria/core/chequeraCuota")
+@FeignClient(name = "tesoreria-core-service", contextId = "chequeraCuotaClient", path = "/api/tesoreria/core/chequeraCuota")
 public interface ChequeraCuotaClient {
 
     @GetMapping("/periodos/lectivo/{lectivoId}")

--- a/src/main/java/um/tesoreria/report/client/core/ChequeraPagoClient.java
+++ b/src/main/java/um/tesoreria/report/client/core/ChequeraPagoClient.java
@@ -1,0 +1,18 @@
+package um.tesoreria.report.client.core;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import um.tesoreria.report.domain.dto.core.ChequeraPagoDto;
+
+import java.util.List;
+
+@FeignClient(name = "tesoreria-core-service", contextId = "chequeraPagoClient", path = "/api/tesoreria/core/chequeraPago")
+public interface ChequeraPagoClient {
+
+    @GetMapping("/pagos/facultad/{facultadId}/tipoChequera/{tipoChequeraId}/lectivo/{lectivoId}")
+    List<ChequeraPagoDto> findAllByFacultadIdAndTipoChequeraIdAndLectivoId(@PathVariable Integer facultadId,
+                                                                           @PathVariable Integer tipoChequeraId,
+                                                                           @PathVariable Integer lectivoId);
+
+}

--- a/src/main/java/um/tesoreria/report/client/core/ChequeraSerieClient.java
+++ b/src/main/java/um/tesoreria/report/client/core/ChequeraSerieClient.java
@@ -7,7 +7,7 @@ import um.tesoreria.report.domain.dto.ChequeraSerieDto;
 
 import java.util.List;
 
-@FeignClient(name = "tesoreria-core-service/api/tesoreria/core/chequeraSerie")
+@FeignClient(name = "tesoreria-core-service", contextId = "chequeraSerieClient", path = "/api/tesoreria/core/chequeraSerie")
 public interface ChequeraSerieClient {
 
     @GetMapping("/lectivo/{facultadId}/{lectivoId}")

--- a/src/main/java/um/tesoreria/report/client/core/FacultadClient.java
+++ b/src/main/java/um/tesoreria/report/client/core/FacultadClient.java
@@ -1,0 +1,14 @@
+package um.tesoreria.report.client.core;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import um.tesoreria.report.domain.dto.FacultadDto;
+
+@FeignClient(name = "tesoreria-core-service", contextId = "facultadClient", path = "/api/tesoreria/core/lectivo")
+public interface FacultadClient {
+
+    @GetMapping("/{facultadId}")
+    FacultadDto findByFacultadId(@PathVariable Integer facultadId);
+
+}

--- a/src/main/java/um/tesoreria/report/client/core/LectivoClient.java
+++ b/src/main/java/um/tesoreria/report/client/core/LectivoClient.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import um.tesoreria.report.domain.dto.LectivoDto;
 
-@FeignClient(name = "tesoreria-core-service/api/tesoreria/core/lectivo")
+@FeignClient(name = "tesoreria-core-service", contextId = "lectivoClient", path = "/api/tesoreria/core/lectivo")
 public interface LectivoClient {
 
     @GetMapping("/{lectivoId}")

--- a/src/main/java/um/tesoreria/report/client/core/LegajoClient.java
+++ b/src/main/java/um/tesoreria/report/client/core/LegajoClient.java
@@ -7,7 +7,7 @@ import um.tesoreria.report.domain.dto.core.LegajoDto;
 
 import java.util.List;
 
-@FeignClient(name = "tesoreria-core-service/api/tesoreria/core/legajo")
+@FeignClient(name = "tesoreria-core-service", contextId = "legajoClient", path = "/api/tesoreria/core/legajo")
 public interface LegajoClient {
 
     @GetMapping("/facultad/{facultadId}")

--- a/src/main/java/um/tesoreria/report/client/core/TipoChequeraClient.java
+++ b/src/main/java/um/tesoreria/report/client/core/TipoChequeraClient.java
@@ -1,0 +1,15 @@
+package um.tesoreria.report.client.core;
+
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import um.tesoreria.report.domain.dto.TipoChequeraDto;
+
+@FeignClient(name = "tesoreria-core-service", contextId = "tipoChequeraClient", path = "/api/tesoreria/core/tipoChequera")
+public interface TipoChequeraClient {
+
+    @GetMapping("/{tipoChequeraId}")
+    TipoChequeraDto findByTipoChequeraId(@PathVariable Integer tipoChequeraId);
+
+}

--- a/src/main/java/um/tesoreria/report/controller/ChequerasController.java
+++ b/src/main/java/um/tesoreria/report/controller/ChequerasController.java
@@ -31,4 +31,12 @@ public class ChequerasController {
         return generateFile(service.generatePlanillaDetalle(facultadId, lectivoId), "planilla.xlsx");
     }
 
+    @GetMapping("/planilla/pagos/facultad/{facultadId}/tipoChequera/{tipoChequeraId}/lectivo/{lectivoId}")
+    public ResponseEntity<Resource> generatePlanillaPagos(@PathVariable Integer facultadId,
+                                                          @PathVariable Integer tipoChequeraId,
+                                                          @PathVariable Integer lectivoId) throws FileNotFoundException {
+        log.debug("Processing ChequerasController.generatePlanillaPagos");
+        return generateFile(service.generatePlanillaPagos(facultadId, tipoChequeraId, lectivoId), "pagos.xlsx");
+    }
+
 }

--- a/src/main/java/um/tesoreria/report/domain/dto/ChequeraCuotaDto.java
+++ b/src/main/java/um/tesoreria/report/domain/dto/ChequeraCuotaDto.java
@@ -1,0 +1,60 @@
+package um.tesoreria.report.domain.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import um.tesoreria.report.domain.dto.core.ProductoDto;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChequeraCuotaDto {
+
+    private Long chequeraCuotaId;
+    private Long chequeraId;
+    private Integer facultadId;
+    private Integer tipoChequeraId;
+    private Long chequeraSerieId;
+    private Integer productoId;
+    private Integer alternativaId;
+    private Integer cuotaId;
+    private Integer mes;
+    private Integer anho;
+    private Integer arancelTipoId;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    private OffsetDateTime vencimiento1;
+
+    private BigDecimal importe1;
+    private BigDecimal importe1Original;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    private OffsetDateTime vencimiento2;
+
+    private BigDecimal importe2;
+    private BigDecimal importe2Original;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    private OffsetDateTime vencimiento3;
+
+    private BigDecimal importe3;
+    private BigDecimal importe3Original;
+    private String codigoBarras;
+    private String i2Of5;
+    private Byte pagado;
+    private Byte baja;
+    private Byte manual;
+    private Byte compensada;
+    private Integer tramoId;
+    private FacultadDto facultad;
+    private TipoChequeraDto tipoChequera;
+    private ProductoDto producto;
+    private ChequeraSerieDto chequeraSerie;
+
+}

--- a/src/main/java/um/tesoreria/report/domain/dto/core/ChequeraPagoDto.java
+++ b/src/main/java/um/tesoreria/report/domain/dto/core/ChequeraPagoDto.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import um.tesoreria.report.domain.dto.ChequeraCuotaDto;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
@@ -14,6 +15,7 @@ import java.time.OffsetDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChequeraPagoDto {
+
     private Long chequeraPagoId;
     private Long chequeraCuotaId;
     private Integer facultadId;
@@ -42,5 +44,7 @@ public class ChequeraPagoDto {
     private Integer tipoPagoId;
     private String idMercadoPago;
     private TipoPagoDto tipoPago;
+    private ProductoDto producto;
+    private ChequeraCuotaDto chequeraCuota;
 
 }

--- a/src/main/java/um/tesoreria/report/service/ChequerasService.java
+++ b/src/main/java/um/tesoreria/report/service/ChequerasService.java
@@ -1,19 +1,13 @@
 package um.tesoreria.report.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
-import um.tesoreria.report.client.core.ChequeraCuotaClient;
-import um.tesoreria.report.client.core.ChequeraSerieClient;
-import um.tesoreria.report.client.core.LectivoClient;
-import um.tesoreria.report.client.core.LegajoClient;
+import um.tesoreria.report.client.core.*;
 import um.tesoreria.report.client.core.facade.ChequeraClient;
 import um.tesoreria.report.domain.dto.ChequeraSerieDto;
-import um.tesoreria.report.domain.dto.core.ChequeraPagoDto;
 import um.tesoreria.report.domain.dto.core.CuotaPeriodoDto;
 
 import java.io.File;
@@ -22,7 +16,6 @@ import java.math.BigDecimal;
 import java.text.MessageFormat;
 import java.time.OffsetDateTime;
 import java.util.Date;
-import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
@@ -35,14 +28,25 @@ public class ChequerasService {
     private final ChequeraCuotaClient chequeraCuotaClient;
     private final ChequeraClient chequeraClient;
     private final LegajoClient legajoClient;
+    private final FacultadClient facultadClient;
+    private final TipoChequeraClient tipoChequeraClient;
+    private final ChequeraPagoClient chequeraPagoClient;
 
-    public ChequerasService(Environment environment, ChequeraSerieClient chequeraSerieClient, LectivoClient lectivoClient, ChequeraCuotaClient chequeraCuotaClient, ChequeraClient chequeraClient, LegajoClient legajoClient) {
+    public ChequerasService(Environment environment,
+                            ChequeraSerieClient chequeraSerieClient,
+                            LectivoClient lectivoClient,
+                            ChequeraCuotaClient chequeraCuotaClient,
+                            ChequeraClient chequeraClient,
+                            LegajoClient legajoClient, FacultadClient facultadClient, TipoChequeraClient tipoChequeraClient, ChequeraPagoClient chequeraPagoClient) {
         this.environment = environment;
         this.chequeraSerieClient = chequeraSerieClient;
         this.lectivoClient = lectivoClient;
         this.chequeraCuotaClient = chequeraCuotaClient;
         this.chequeraClient = chequeraClient;
         this.legajoClient = legajoClient;
+        this.facultadClient = facultadClient;
+        this.tipoChequeraClient = tipoChequeraClient;
+        this.chequeraPagoClient = chequeraPagoClient;
     }
 
     public String generatePlanillaDetalle(Integer facultadId, Integer lectivoId) {
@@ -173,18 +177,68 @@ public class ChequerasService {
         return filename;
     }
 
-    private void logPagos(List<ChequeraPagoDto> chequeraPagos) {
-        log.debug("Processing ChequerasService.logPagos");
-        try {
-            log.debug("Pagos -> {}", JsonMapper
-                    .builder()
-                    .findAndAddModules()
-                    .build()
-                    .writerWithDefaultPrettyPrinter()
-                    .writeValueAsString(chequeraPagos));
-        } catch (JsonProcessingException e) {
-            log.debug("Pagos jsonify error -> {}", e.getMessage());
+    public String generatePlanillaPagos(Integer facultadId, Integer tipoChequeraId, Integer lectivoId) {
+        log.debug("Processing ChequerasService.generatePlanillaPagos");
+        String path = environment.getProperty("path.reports");
+
+        String filename = path + MessageFormat.format("pagos.{0}.{1}.{2}.xlsx", facultadId, tipoChequeraId, lectivoId);
+
+        Workbook book = new XSSFWorkbook();
+        CellStyle styleNormal = book.createCellStyle();
+        Font fontNormal = book.createFont();
+        fontNormal.setBold(false);
+        styleNormal.setFont(fontNormal);
+
+        CellStyle styleBold = book.createCellStyle();
+        Font fontBold = book.createFont();
+        fontBold.setBold(true);
+        styleBold.setFont(fontBold);
+
+        Sheet sheet = book.createSheet("pagos");
+        Row row;
+        int fila = 0;
+        row = sheet.createRow(fila);
+        this.setCellString(row, 0, "Facultad", styleBold);
+        this.setCellString(row, 1, "Lectivo", styleBold);
+        this.setCellString(row, 2, "Tipo de Chequera", styleBold);
+        this.setCellString(row, 3, "Sede", styleBold);
+        this.setCellString(row, 4, "Documento", styleBold);
+        this.setCellString(row, 5, "Apellido, Nombre", styleBold);
+        this.setCellString(row, 6, "Chequera", styleBold);
+        this.setCellString(row, 7, "Periodo", styleBold);
+        this.setCellString(row, 8, "Fecha Pago", styleBold);
+        this.setCellString(row, 9, "Importe Pagado", styleBold);
+        this.setCellString(row, 10, "Tipo Pago", styleBold);
+
+        for (var chequeraPago : chequeraPagoClient.findAllByFacultadIdAndTipoChequeraIdAndLectivoId(facultadId, tipoChequeraId, lectivoId)) {
+            row = sheet.createRow(++fila);
+            this.setCellString(row, 0, chequeraPago.getChequeraCuota().getFacultad().getNombre(), styleNormal);
+            this.setCellString(row, 1, chequeraPago.getChequeraCuota().getChequeraSerie().getLectivo().getNombre(), styleNormal);
+            this.setCellString(row, 2, chequeraPago.getChequeraCuota().getTipoChequera().getNombre(), styleNormal);
+            this.setCellString(row, 3, chequeraPago.getChequeraCuota().getChequeraSerie().getGeografica().getNombre(), styleNormal);
+            this.setCellBigDecimal(row, 4, chequeraPago.getChequeraCuota().getChequeraSerie().getPersonaId(), styleNormal);
+            this.setCellString(row, 5, MessageFormat.format("{0}, {1}", chequeraPago.getChequeraCuota().getChequeraSerie().getPersona().getApellido(), chequeraPago.getChequeraCuota().getChequeraSerie().getPersona().getNombre()), styleNormal);
+            this.setCellString(row, 6, MessageFormat.format("{0,number,#}/{1,number,#}/{2,number,#}", chequeraPago.getFacultadId(), chequeraPago.getTipoChequeraId(), chequeraPago.getChequeraSerieId()), styleNormal);
+            this.setCellString(row, 7, MessageFormat.format("{0}/{1,number,#}", chequeraPago.getMes(), chequeraPago.getAnho()), styleNormal);
+            this.setCellOffsetDateTime(row, 8, chequeraPago.getFecha(), styleNormal);
+            this.setCellBigDecimal(row, 9, chequeraPago.getImporte(), styleNormal);
+            this.setCellString(row, 10, chequeraPago.getTipoPago().getNombre(), styleNormal);
         }
+
+        for (int column = 0; column < sheet.getRow(0).getPhysicalNumberOfCells(); column++)
+            sheet.autoSizeColumn(column);
+
+        try {
+            File file = new File(filename);
+            FileOutputStream output = new FileOutputStream(file);
+            book.write(output);
+            output.flush();
+            output.close();
+            book.close();
+        } catch (Exception e) {
+            log.debug("Error escribiendo pagos");
+        }
+        return filename;
     }
 
     private void setCellOffsetDateTime(Row row, int column, OffsetDateTime value, CellStyle style) {

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -48,4 +48,7 @@ logging:
         security: ${app.logging}
     feign: ${app.logging}
     feign.hystrix: ${app.logging}
-
+management:
+  health:
+    mail:
+      enabled: false


### PR DESCRIPTION
Introduce una nueva funcionalidad para generar y descargar un reporte de planilla de pagos en formato Excel.

- Añade el endpoint GET /planilla/pagos/{facultadId}/{tipoChequeraId}/{lectivoId}.
- Implementa la lógica en `ChequerasService` para recopilar y formatear los datos de pagos.
- Crea nuevos clientes Feign (`ChequeraPagoClient`, `FacultadClient`, `TipoChequeraClient`) para comunicarse con el servicio principal.
- Refactoriza los clientes Feign existentes para estandarizar su configuración y mejorar la mantenibilidad.

Closes: #34