### PR TITLE
chore(deps): actualizar dependencias y versión de Java 25

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,10 +18,10 @@ jobs:
           # Fetch all history for all branches and tags.
           # SonarCloud needs this to perform analysis on PRs.
           fetch-depth: 0
-      - name: Set up JDK 24
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'temurin'
       - name: Cache SonarCloud packages
         uses: actions/cache@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-02-03
+### Changed
+- **chore:** Actualización de Spring Boot de 3.5.8 a 4.0.2
+- **chore:** Actualización de Java de 24 a 25
+- **chore:** Actualización de Spring Cloud de 2025.0.0 a 2025.1.0
+- **chore:** Actualización de SpringDoc OpenAPI de 2.8.10 a 3.0.1
+- **chore:** Actualización de Apache POI de 5.4.1 a 5.5.1
+- **chore:** Actualización de ModelMapper de 3.2.4 a 3.2.6
+- **chore:** Actualización de Apache Commons Lang3 de 3.18.0 a 3.20.0
+- **chore:** Actualización de GitHub Actions workflow para usar JDK 25
+- **chore:** Actualización de Dockerfile para usar JDK/JRE 25
+
+### Removed
+- **chore:** Eliminación de configuración executable del Spring Boot Maven Plugin
+
 ## [0.4.1] - 2025-10-22
 ### Changed
 - **chore:** Actualización de Spring Boot de 3.5.5 a 3.5.6.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Etapa 1: Compilación con Maven y JDK
 # Usamos una imagen oficial que contiene Maven y Java (Temurin)
-FROM maven:3-eclipse-temurin-24-alpine AS build
+FROM maven:3-eclipse-temurin-25-alpine AS build
 
 # Establecemos el directorio de trabajo
 WORKDIR /app
@@ -19,7 +19,7 @@ RUN mvn clean package
 
 # Etapa 2: Creación de la imagen final y ligera
 # Usamos una imagen solo con el JRE, que es más pequeña
-FROM eclipse-temurin:24-jre-alpine
+FROM eclipse-temurin:25-jre-alpine
 
 # Instalar curl en la imagen final
 RUN apk update && apk add curl

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 
 # UM.tesoreria.report-service
 
-[![Java](https://img.shields.io/badge/Java-21-blue)](https://www.java.com/)
-[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.6-brightgreen)](https://spring.io/projects/spring-boot)
-[![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.0.0-brightgreen)](https://spring.io/projects/spring-cloud)
-[![SpringDoc OpenAPI](https://img.shields.io/badge/SpringDoc%20OpenAPI-2.8.10-blue)](https://springdoc.org/)
-[![Apache POI](https://img.shields.io/badge/Apache%20POI-5.4.1-red)](https://poi.apache.org/)
+[![Java](https://img.shields.io/badge/Java-25-blue)](https://www.java.com/)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.2-brightgreen)](https://spring.io/projects/spring-boot)
+[![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.0-brightgreen)](https://spring.io/projects/spring-cloud)
+[![SpringDoc OpenAPI](https://img.shields.io/badge/SpringDoc%20OpenAPI-3.0.1-blue)](https://springdoc.org/)
+[![Apache POI](https://img.shields.io/badge/Apache%20POI-5.5.1-red)](https://poi.apache.org/)
 [![Lombok](https://img.shields.io/badge/Lombok-1.18.30-pink)](https://projectlombok.org/)
 
 ## Estado del Proyecto
@@ -29,12 +29,12 @@ Servicio de generación de reportes y documentos para UM Tesorería. Este micros
 
 ## Tecnologías
 
-- Java 21
-- Spring Boot 3.5.5
-- Spring Cloud 2025.0.0
+- Java 25
+- Spring Boot 4.0.2
+- Spring Cloud 2025.1.0
 - Caffeine (para caché)
-- SpringDoc OpenAPI 2.8.10
-- Apache POI 5.4.1 (para reportes Excel)
+- SpringDoc OpenAPI 3.0.1
+- Apache POI 5.5.1 (para reportes Excel)
 - Lombok (para reducir código boilerplate)
 
 ## Documentación
@@ -49,7 +49,7 @@ Servicio de generación de reportes y documentos para UM Tesorería. Este micros
 
 ### Requisitos Previos
 
-- JDK 21
+- JDK 25
 - Maven 3.8.8 o superior
 - Git
 - Docker (opcional, para desarrollo con contenedores)

--- a/pom.xml
+++ b/pom.xml
@@ -5,17 +5,17 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.8</version>
+        <version>4.0.2</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.report</artifactId>
-    <version>0.4.1</version>
+    <version>0.5.0</version>
     <name>UM.tesoreria.report-service</name>
     <description>Spring Boot Report Service</description>
     <properties>
-        <java.version>24</java.version>
-        <spring-cloud.version>2025.0.0</spring-cloud.version>
+        <java.version>25</java.version>
+        <spring-cloud.version>2025.1.0</spring-cloud.version>
         <sonar.organization>um-services</sonar.organization>
         <sonar.projectKey>UM-services_UM.tesoreria.report-service</sonar.projectKey>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.8.10</version>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
@@ -94,17 +94,17 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
-            <version>5.4.1</version>
+            <version>5.5.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>5.4.1</version>
+            <version>5.5.1</version>
         </dependency>
         <dependency>
             <groupId>org.modelmapper</groupId>
             <artifactId>modelmapper</artifactId>
-            <version>3.2.4</version>
+            <version>3.2.6</version>
         </dependency>
     </dependencies>
 
@@ -113,7 +113,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.18.0</version>
+                <version>3.20.0</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
@@ -131,9 +131,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <executable>true</executable>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Closes #47

## Descripción
Actualización de dependencias principales y versión de Java para la versión 0.5.0 del servicio de reportes.

## Cambios Realizados
- **Java:** Actualización de 24 a 25
- **Spring Boot:** Actualización de 3.5.8 a 4.0.2
- **Spring Cloud:** Actualización de 2025.0.0 a 2025.1.0
- **SpringDoc OpenAPI:** Actualización de 2.8.10 a 3.0.1
- **Apache POI:** Actualización de 5.4.1 a 5.5.1
- **ModelMapper:** Actualización de 3.2.4 a 3.2.6
- **Apache Commons Lang3:** Actualización de 3.18.0 a 3.20.0
- **GitHub Actions:** Workflow actualizado para usar JDK 25
- **Dockerfile:** Imagen base actualizada a Eclipse Temurin 25
- **Documentación:** README.md y CHANGELOG.md actualizados

## Verificación
- El proyecto compila correctamente con Maven
- Las dependencias se resolvieron exitosamente
- El workflow de GitHub Actions ha sido probado
- El Dockerfile se construye sin errores
