### PR TITLE
feat(report): add email columns to payment sheet (v0.6.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
+.agents/
 
 ### STS ###
 .apt_generated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-02-16
+
+### Added
+- **feat:** Agregadas columnas de email en la planilla de pagos (`generatePlanillaPagos`)
+  - Nueva columna: "e-mail Institucional" - extrae el email institucional del domicilio asociado a la chequera
+  - Nueva columna: "e-mail Personal" - extrae el email personal del domicilio asociado a la chequera
+  - Los datos se obtienen a través de la relación `chequeraPago.chequeraCuota.chequeraSerie.domicilio`
+
 ## [0.5.0] - 2026-02-03
 ### Changed
 - **chore:** Actualización de Spring Boot de 3.5.8 a 4.0.2

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Servicio de generación de reportes y documentos para UM Tesorería. Este micros
 
 - Generación de reportes Excel de chequeras y planillas
 - **NUEVO:** Generación de planillas de detalle por sede (geográfica)
+- **NUEVO:** Planillas de pagos con información de contacto (emails institucional y personal)
 - Integración con servicios core de Tesorería (Chequera, Legajo, Lectivo, Geográfica)
 - Endpoints REST para descarga de reportes
 - Configuración avanzada con Spring Cloud y Consul

--- a/docs/diagrams/generacion-reporte.mmd
+++ b/docs/diagrams/generacion-reporte.mmd
@@ -4,14 +4,27 @@ sequenceDiagram
     participant ChequerasController
     participant ChequerasService
     participant ChequeraClient
+    participant ChequeraPagoClient
+    participant LegajoClient
 
-    User->>+ChequerasController: GET /chequeras/reporte
-    ChequerasController->>+ChequerasService: generarReporte()
-    ChequerasService->>+ChequeraClient: getDatosChequera()
-    ChequeraClient-->>-ChequerasService: Datos Chequera
-    ChequerasService->>+ChequeraClient: getPagos()
-    ChequeraClient-->>-ChequerasService: Lista de Pagos
-    ChequerasService-->>-ChequerasController: Reporte (Excel)
+    User->>+ChequerasController: GET /planilla/pagos/{facultadId}/{tipoChequeraId}/{lectivoId}
+    ChequerasController->>+ChequerasService: generatePlanillaPagos()
+    ChequerasService->>+ChequeraPagoClient: findAllByFacultadIdAndTipoChequeraIdAndLectivoId()
+    ChequeraPagoClient-->>-ChequerasService: Lista de ChequeraPago
+    loop Para cada pago
+        ChequerasService->>ChequerasService: Extraer datos de cuota, serie y domicilio
+        Note over ChequerasService: Incluye email institucional y personal<br/>desde chequeraSerie.domicilio
+    end
+    ChequerasService-->>-ChequerasController: Reporte Excel con columnas de email
+    ChequerasController-->>-User: ResponseEntity<byte[]>
+
+    User->>+ChequerasController: GET /planilla/detalle/{facultadId}/{lectivoId}/{geograficaId}
+    ChequerasController->>+ChequerasService: generatePlanillaDetalle()
+    ChequerasService->>+ChequeraClient: findAllCuotaPagosByChequera()
+    ChequeraClient-->>-ChequerasService: Datos de cuotas y pagos
+    ChequerasService->>+LegajoClient: findAllByFacultadId()
+    LegajoClient-->>-ChequerasService: Información de legajos
+    ChequerasService-->>-ChequerasController: Reporte Excel detallado
     ChequerasController-->>-User: ResponseEntity<byte[]>
 ```
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.report</artifactId>
-    <version>0.5.0</version>
+    <version>0.6.0</version>
     <name>UM.tesoreria.report-service</name>
     <description>Spring Boot Report Service</description>
     <properties>

--- a/src/main/java/um/tesoreria/report/service/ChequerasService.java
+++ b/src/main/java/um/tesoreria/report/service/ChequerasService.java
@@ -248,6 +248,8 @@ public class ChequerasService {
         this.setCellString(row, 8, "Fecha Pago", styleBold);
         this.setCellString(row, 9, "Importe Pagado", styleBold);
         this.setCellString(row, 10, "Tipo Pago", styleBold);
+        this.setCellString(row, 11, "e-mail Institucional", styleBold);
+        this.setCellString(row, 12, "e-mail Personal", styleBold);
 
         for (var chequeraPago : chequeraPagoClient.findAllByFacultadIdAndTipoChequeraIdAndLectivoId(facultadId, tipoChequeraId, lectivoId)) {
             row = sheet.createRow(++fila);
@@ -262,6 +264,8 @@ public class ChequerasService {
             this.setCellOffsetDateTime(row, 8, chequeraPago.getFecha(), styleNormal);
             this.setCellBigDecimal(row, 9, chequeraPago.getImporte(), styleNormal);
             this.setCellString(row, 10, chequeraPago.getTipoPago().getNombre(), styleNormal);
+            this.setCellString(row, 11, chequeraPago.getChequeraCuota().getChequeraSerie().getDomicilio().getEmailInstitucional(), styleNormal);
+            this.setCellString(row, 12, chequeraPago.getChequeraCuota().getChequeraSerie().getDomicilio().getEmailPersonal(), styleNormal);
         }
 
         for (int column = 0; column < sheet.getRow(0).getPhysicalNumberOfCells(); column++)


### PR DESCRIPTION
Closes #49

## Descripción
Esta PR implementa la funcionalidad para agregar columnas de email en la planilla de pagos como parte de la versión 0.6.0.

Se agregaron dos nuevas columnas al reporte Excel generado por el método `generatePlanillaPagos`:
- **e-mail Institucional**: Extrae el email institucional del domicilio asociado a la chequera
- **e-mail Personal**: Extrae el email personal del domicilio asociado a la chequera

Los datos se obtienen a través de la relación: `chequeraPago.chequeraCuota.chequeraSerie.domicilio`

## Cambios Realizados
- [x] Actualizada versión del proyecto de 0.5.0 a 0.6.0 en `pom.xml`
- [x] Implementación de las nuevas columnas en `ChequerasService.java`
- [x] Agregada entrada en `CHANGELOG.md` con descripción de la versión 0.6.0
- [x] Actualizada documentación en `README.md` con la nueva funcionalidad
- [x] Actualizado diagrama de secuencia en `docs/diagrams/generacion-reporte.mmd`
- [x] Agregado `.agents/` a `.gitignore`

## Verificación
- [x] Commit con mensaje convencional: `feat(report): add institutional and personal email columns...`
- [x] Código revisado y probado localmente
- [x] Documentación actualizada
