### PR TITLE
feat(report): add HPUM and Beca columns to chequera detail

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -43,6 +43,7 @@ jobs:
           curl -s -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/${{ github.repository }}/issues?state=all&per_page=100" > issues.json
           curl -s -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/${{ github.repository }}/pulls?state=all&per_page=100" > prs.json
           
+          # --- Write HTML header (before diagram sections) ---
           cat > docs/index.html << 'EOF'
           <!DOCTYPE html>
           <html lang="es">
@@ -74,8 +75,34 @@ jobs:
                   <p>Última actualización: <span id="update-date"></span></p>
               </div>
               <div id="stats" class="stats"></div>
-              <div id="architecture" class="section"></div>
-              <div id="sequence-diagram" class="section"></div>
+          EOF
+          
+          # --- Inject architecture diagram ---
+          cat >> docs/index.html << 'EOF'
+              <div id="architecture" class="section">
+                  <h2>🏗️ Arquitectura General</h2>
+                  <div class="mermaid">
+          EOF
+          sed '1d;$d' docs/diagrams/arquitectura-general.mmd >> docs/index.html
+          cat >> docs/index.html << 'EOF'
+                  </div>
+              </div>
+          EOF
+          
+          # --- Inject sequence diagram ---
+          cat >> docs/index.html << 'EOF'
+              <div id="sequence-diagram" class="section">
+                  <h2>🔄 Diagrama de Secuencia: Generación de Reportes</h2>
+                  <div class="mermaid">
+          EOF
+          sed '1d;$d' docs/diagrams/generacion-reporte.mmd >> docs/index.html
+          cat >> docs/index.html << 'EOF'
+                  </div>
+              </div>
+          EOF
+          
+          # --- Write HTML footer (dependencies, milestones, scripts) ---
+          cat >> docs/index.html << 'EOF'
               <div id="dependencies" class="section">
                   <h2>🌳 Grafo de Dependencias</h2>
                   <p>El siguiente es el árbol de dependencias completo del proyecto, generado por Maven.</p>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-06-11
+
+### Added
+- **feat:** Agregadas columnas "HPUM" y "Beca" en la planilla de detalle de chequeras (`generatePlanillaDetalle`)
+  - Nueva columna "HPUM": marca con "X" si la chequera tiene habilitado HPUM (campo `hpum` en `ChequeraSerieDto`)
+  - Nueva columna "Beca": muestra el porcentaje de beca asociado (`becaPorcentaje` en `ChequeraSerieDto`)
+  - Nuevos campos en DTO: `becaResolucion`, `becaFecha`, `becaUserId` para soporte completo de datos de beca
+- **chore:** Nueva dependencia `commons-fileupload:1.6.0` para manejo de subida de archivos
+
+### Changed
+- **refactor:** Extracción del método `jsonify()` en `ChequeraSerieDto` a la utilidad `Jsonifier.builder(this).build()`
+- **chore:** Actualización de Spring Boot de 4.0.5 a 4.0.7
+- **chore:** Actualización de GitHub Actions:
+  - `actions/checkout@v4` → `v6`
+  - `actions/setup-java@v4` → `v5`
+  - `actions/cache@v4` → `v5`
+  - `actions/upload-pages-artifact@v3` → `v4`
+  - `actions/deploy-pages@v4` → `v5`
+  - `docker/login-action@v3` → `v4`
+  - `docker/metadata-action@v5` → `v6`
+  - `docker/setup-buildx-action@v3` → `v4`
+  - `docker/build-push-action@v6` → `v7`
+
+### Docs
+- **docs:** Actualización de diagramas Mermaid para reflejar nuevas columnas HPUM y Beca
+- **docs:** Corrección en pipeline de documentación para incluir diagramas Mermaid en la página generada
+
 ## [0.7.0] - 2026-03-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # UM.tesoreria.report-service
 
 [![Java](https://img.shields.io/badge/Java-25-blue)](https://www.java.com/)
-[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.5-brightgreen)](https://spring.io/projects/spring-boot)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.7-brightgreen)](https://spring.io/projects/spring-boot)
 [![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.0-brightgreen)](https://spring.io/projects/spring-cloud)
 [![SpringDoc OpenAPI](https://img.shields.io/badge/SpringDoc%20OpenAPI-3.0.2-blue)](https://springdoc.org/)
 [![Apache POI](https://img.shields.io/badge/Apache%20POI-5.5.1-red)](https://poi.apache.org/)
@@ -17,9 +17,9 @@ Servicio de generación de reportes y documentos para UM Tesorería. Este micros
 
 ## Características Principales
 
-- Generación de reportes Excel de chequeras y planillas
-- **NUEVO:** Generación de planillas de detalle por sede (geográfica)
-- **NUEVO:** Planillas de pagos con información de contacto (emails institucional y personal)
+- Generación de reportes Excel de chequeras y planillas (incluye columnas HPUM, Beca e ID Mercado Pago)
+- Generación de planillas de detalle por sede (geográfica)
+- Planillas de pagos con información de contacto (emails institucional y personal)
 - Integración con servicios core de Tesorería (Chequera, Legajo, Lectivo, Geográfica)
 - Endpoints REST para descarga de reportes
 - Configuración avanzada con Spring Cloud y Consul
@@ -31,7 +31,7 @@ Servicio de generación de reportes y documentos para UM Tesorería. Este micros
 ## Tecnologías
 
 - Java 25
-- Spring Boot 4.0.5
+- Spring Boot 4.0.7
 - Spring Cloud 2025.1.0
 - Caffeine (para caché)
 - SpringDoc OpenAPI 3.0.2

--- a/docs/diagrams/generacion-reporte.mmd
+++ b/docs/diagrams/generacion-reporte.mmd
@@ -24,8 +24,8 @@ sequenceDiagram
     ChequeraClient-->>-ChequerasService: Datos de cuotas y pagos
     ChequerasService->>+LegajoClient: findAllByFacultadId()
     LegajoClient-->>-ChequerasService: Información de legajos
-    Note over ChequerasService: Incluye columna id MP (Mercado Pago)<br/>para cada pago en el período
-    ChequerasService-->>-ChequerasController: Reporte Excel con columna id MP
+    Note over ChequerasService: Incluye columnas: id MP (Mercado Pago),<br/>HPUM y Beca para cada chequera
+    ChequerasService-->>-ChequerasController: Reporte Excel con columnas<br/>id MP, HPUM y Beca
     ChequerasController-->>-User: ResponseEntity<byte[]>
 ```
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.5</version>
+        <version>4.0.7</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.report</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0</version>
     <name>UM.tesoreria.report-service</name>
     <description>Spring Boot Report Service</description>
     <properties>

--- a/src/main/java/um/tesoreria/report/domain/dto/ChequeraSerieDto.java
+++ b/src/main/java/um/tesoreria/report/domain/dto/ChequeraSerieDto.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import um.tesoreria.report.util.Jsonifier;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
@@ -38,6 +39,14 @@ public class ChequeraSerieDto {
     private Byte enviado = 0;
     private Byte retenida = 0;
     private Long version;
+    private Byte hpum = 0;
+    private BigDecimal becaPorcentaje = BigDecimal.ZERO;
+    private String becaResolucion;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    private OffsetDateTime becaFecha;
+
+    private Long becaUserId;
     private Integer cuotasDeuda = 0;
     private BigDecimal importeDeuda = BigDecimal.ZERO;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
@@ -52,16 +61,7 @@ public class ChequeraSerieDto {
     private GeograficaDto geografica;
 
     public String jsonify() {
-        try {
-            return JsonMapper
-                    .builder()
-                    .findAndAddModules()
-                    .build()
-                    .writerWithDefaultPrettyPrinter()
-                    .writeValueAsString(this);
-        } catch (JsonProcessingException e) {
-            return "jsonify error: " + e.getMessage();
-        }
+        return Jsonifier.builder(this).build();
     }
 
 }

--- a/src/main/java/um/tesoreria/report/service/ChequerasService.java
+++ b/src/main/java/um/tesoreria/report/service/ChequerasService.java
@@ -75,6 +75,8 @@ public class ChequerasService {
         this.setCellString(row, 5, "Carrera", styleBold);
         this.setCellString(row, 6, "Curso", styleBold);
         this.setCellString(row, 7, "Tipo Chequera", styleBold);
+        this.setCellString(row, 8, "HPUM", styleBold);
+        this.setCellString(row, 9, "Beca", styleBold);
 
         // Cambiar en producción
 //        var allChequeras = chequeraSerieClient.findAllByLectivoTest(facultadId, lectivoId);
@@ -83,7 +85,7 @@ public class ChequerasService {
         var periodos = chequeraCuotaClient.findAllPeriodosLectivo(lectivoId);
 
         // Add period headers starting from column 8
-        int periodoColumn = 8;
+        int periodoColumn = 10;
         for (CuotaPeriodoDto periodo : periodos) {
             this.setCellString(row, periodoColumn++, MessageFormat.format("{0}/{1,number,#} Producto", periodo.getMes(), periodo.getAnho()), styleBold);
             this.setCellString(row, periodoColumn++, MessageFormat.format("{0}/{1,number,#} Importe", periodo.getMes(), periodo.getAnho()), styleBold);
@@ -130,8 +132,10 @@ public class ChequerasService {
             this.setCellString(row, 5, carrera, styleNormal);
             this.setCellInteger(row, 6, chequeraSerie.getCursoId(), styleNormal);
             this.setCellString(row, 7, chequeraSerie.getTipoChequera().getNombre(), styleNormal);
+            this.setCellString(row, 8, chequeraSerie.getHpum() == 1 ? "X" : "", styleNormal);
+            this.setCellBigDecimal(row, 9, chequeraSerie.getBecaPorcentaje(), styleNormal);
 
-            periodoColumn = 8;
+            periodoColumn = 10;
             int maxOffset = 0;
             for (CuotaPeriodoDto periodo : periodos) {
                 log.debug("Periodo: {}", periodo.jsonify());
@@ -159,6 +163,8 @@ public class ChequerasService {
                         this.setCellString(innerRow, 5, carrera, styleNormal);
                         this.setCellInteger(innerRow, 6, chequeraSerie.getCursoId(), styleNormal);
                         this.setCellString(innerRow, 7, chequeraSerie.getTipoChequera().getNombre(), styleNormal);
+                        this.setCellString(innerRow, 8, chequeraSerie.getHpum() == 1 ? "X" : "", styleNormal);
+                        this.setCellBigDecimal(innerRow, 9, chequeraSerie.getBecaPorcentaje(), styleNormal);
 
                         log.debug("Cuota a escribir -> {}", Jsonifier.builder(cuota).build());
                         this.setCellString(innerRow, periodoColumn, cuota.getProducto().getNombre(), styleNormal);


### PR DESCRIPTION
Closes #55

## Descripción

Se agregan las columnas **HPUM** y **Beca** en la planilla de detalle de chequeras (`generatePlanillaDetalle`), se actualizan dependencias principales y se mejora la documentación del proyecto.

## Cambios Realizados

- [x] **Nuevas columnas en Excel:** "HPUM" (marca con "X" si `hpum == 1`) y "Beca" (porcentaje de beca) en `ChequerasService.java`
- [x] **Nuevos campos en DTO:** `hpum`, `becaPorcentaje`, `becaResolucion`, `becaFecha`, `becaUserId` en `ChequeraSerieDto.java`
- [x] **Refactor:** Método `jsonify()` extraído a utilidad `Jsonifier.builder(this).build()`
- [x] **Actualización Spring Boot:** 4.0.5 → 4.0.7
- [x] **Actualización GitHub Actions:** 9 actions actualizadas a sus versiones más recientes (checkout@v6, setup-java@v5, cache@v5, etc.)
- [x] **Nueva dependencia:** `commons-fileupload:1.6.0`
- [x] **Documentación:** Diagramas Mermaid actualizados, pipeline de docs corrige la inclusión de diagramas, badges de versión en README actualizados
- [x] **CHANGELOG:** Registro de cambios para v0.8.0

## Verificación

- [ ] Compilar: `mvn clean compile -DskipTests`
- [ ] Ejecutar tests: `mvn test`
- [ ] Verificar que la planilla de detalle incluya las columnas HPUM y Beca
- [ ] Confirmar que los diagramas Mermaid se rendericen correctamente en la documentación generada
