### PR TITLE
chore(chequeras): bump version to 0.10.1 and add debug logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2026-07-02
+
+### Changed
+- **chore:** Añadido log de depuración en `GeneratePlanillaDetalleVerticalUseCaseImpl` para trazabilidad en lectura de pagos
+
 ## [0.10.0] - 2026-06-27
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.report</artifactId>
-    <version>0.10.0</version>
+    <version>0.10.1</version>
     <name>UM.tesoreria.report-service</name>
     <description>Spring Boot Report Service</description>
     <properties>

--- a/src/main/java/um/tesoreria/report/hexagonal/chequeras/application/usecases/GeneratePlanillaDetalleVerticalUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/report/hexagonal/chequeras/application/usecases/GeneratePlanillaDetalleVerticalUseCaseImpl.java
@@ -107,6 +107,7 @@ public class GeneratePlanillaDetalleVerticalUseCaseImpl implements GeneratePlani
                 .map(chequeraSerie -> CompletableFuture.runAsync(() -> {
                     try {
                         semaphore.acquire();
+                        log.debug("\n\nLeyendo pagos\n\n");
                         List<ChequeraCuotaPagos> cuotas = chequeraRepository.findAllCuotaPagosByChequera(
                             chequeraSerie.getFacultadId(),
                             chequeraSerie.getTipoChequeraId(),


### PR DESCRIPTION
Closes #63

## Descripción
Release de parche **v0.10.1** con mejora de trazabilidad en el módulo de chequeras y actualización de versión.

## Cambios Realizados
- Bump de versión de `0.10.0` a `0.10.1` en `pom.xml`
- Registro del release `0.10.1` en `CHANGELOG.md`
- Adición de log de depuración en `GeneratePlanillaDetalleVerticalUseCaseImpl.java` para trazabilidad en lectura de pagos

## Verificación
- Compilación exitosa con `mvn compile`
- Pruebas unitarias y de integración pasan correctamente
