### PR TITLE
feat(contable): nuevo módulo contable con arquitectura hexagonal para planilla de Lectivo Total Imputación

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-07-03
+
+### Added
+- **feat:** Nuevo módulo contable con arquitectura hexagonal para generar planilla de "Lectivo Total Imputación"
+  - Nuevos modelos de dominio: `Cuenta`, `LectivoTotalImputacion`
+  - Nuevo puerto de entrada: `GenerateLectivoTotalImputacionReportUseCase`
+  - Nuevo puerto de salida: `LectivoTotalImputacionRepository`
+  - Nueva capa `application` con servicio fachada (`ContableReportService`) e implementación de caso de uso
+  - Nueva capa `infrastructure` con cliente Feign, adaptador, DTOs (`CuentaDto`, `LectivoTotalImputacionDto`), mapper (`ContableMapper`) y controlador REST
+  - Nuevo endpoint: `GET /api/tesoreria/report/contable/planilla/lectivo/{lectivoId}`
+  - Reporte Excel generado con columnas: Facultad, Tipo Chequera, Geográfica, Producto, Cuenta Contable, Nombre Cuenta
+
+### Changed
+- **chore:** Ampliado escaneo de `@EnableFeignClients` en `ReportConfiguration` para incluir todos los paquetes hexagonales (`um.tesoreria.report.hexagonal`)
+
 ## [0.10.1] - 2026-07-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 # UM.tesoreria.report-service
 
 [![Java](https://img.shields.io/badge/Java-25-blue)](https://www.java.com/)
+[![Version](https://img.shields.io/badge/Version-0.11.0-blue)](https://github.com/UM-services/UM.tesoreria.report-service)
 [![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.1.0-brightgreen)](https://spring.io/projects/spring-boot)
 [![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.2-brightgreen)](https://spring.io/projects/spring-cloud)
 [![SpringDoc OpenAPI](https://img.shields.io/badge/SpringDoc%20OpenAPI-3.0.3-blue)](https://springdoc.org/)
@@ -20,11 +21,12 @@ Servicio de generación de reportes y documentos para UM Tesorería. Este micros
 - Generación de reportes Excel de chequeras y planillas (incluye columnas HPUM, Beca e ID Mercado Pago)
 - Generación de planillas de detalle por sede (geográfica): horizontal y vertical
 - Planillas de pagos con información de contacto (emails institucional y personal)
-- Integración con servicios core de Tesorería (Chequera, Legajo, Lectivo, Geográfica)
+- Generación de planilla de "Lectivo Total Imputación" desde el módulo contable
+- Integración con servicios core de Tesorería (Chequera, Legajo, Lectivo, Geográfica, Contable)
 - Endpoints REST para descarga de reportes
 - Configuración avanzada con Spring Cloud y Consul
 - Documentación automática con SpringDoc OpenAPI
-- Arquitectura hexagonal (puertos y adaptadores) para el módulo de chequeras
+- Arquitectura hexagonal (puertos y adaptadores) para los módulos de chequeras y contable
 - Diagramas de arquitectura y flujo de reportes
 - Utilidades de serialización JSON para debugging y pruebas
 

--- a/docs/diagrams/arquitectura-general.mmd
+++ b/docs/diagrams/arquitectura-general.mmd
@@ -5,8 +5,9 @@ graph TD
     C["Core Service: Legajos"]
     D["Core Service: Lectivo"]
     E["Core Service: Geográfica"]
+    EE["Core Service: Contable"]
 
-    subgraph "Hexagonal: Infrastructure Layer"
+    subgraph "Hexagonal: Infrastructure Layer (Chequeras)"
         F["ChequerasReportController"]
         G["ChequeraSerieClient"]
         H["ChequeraPagoClient"]
@@ -19,30 +20,48 @@ graph TD
         J --> K
     end
 
+    subgraph "Hexagonal: Infrastructure Layer (Contable)"
+        F2["ContableReportController"]
+        G2["LectivoTotalImputacionClient"]
+        J2["FeignLectivoTotalImputacionRepositoryAdapter"]
+        K2["ContableMapper"]
+        G2 --> J2
+        J2 --> K2
+    end
+
     subgraph "Hexagonal: Application Layer"
         L["ChequerasReportService"]
         M["GeneratePlanillaDetalleUseCase"]
         N["GeneratePlanillaPagosUseCase"]
         R["GeneratePlanillaDetalleVerticalUseCase"]
+        L2["ContableReportService"]
+        S["GenerateLectivoTotalImputacionReportUseCaseImpl"]
         L --> M
         L --> N
         L --> R
+        L2 --> S
     end
 
     subgraph "Hexagonal: Domain Layer"
-        O["Domain Model (18 entities)"]
+        O["Domain Model Chequeras (18 entities)"]
+        O2["Domain Model Contable (2 entities)"]
         P["Port In: UseCase Interfaces"]
         Q["Port Out: Repository Interfaces"]
     end
 
     A --> F
+    A --> F2
     F --> L
+    F2 --> L2
     M -.-> P
     N -.-> P
     R -.-> P
+    S -.-> P
     Q -.-> J
+    Q -.-> J2
     J --> B
     J --> C
     J --> D
     J --> E
+    J2 --> EE
 ```

--- a/docs/diagrams/generacion-reporte.mmd
+++ b/docs/diagrams/generacion-reporte.mmd
@@ -6,6 +6,11 @@ sequenceDiagram
     participant GeneratePlanillaPagosUseCase
     participant GeneratePlanillaDetalleUseCase
     participant GeneratePlanillaDetalleVerticalUseCase
+    participant ContableReportController
+    participant ContableReportService
+    participant GenerateLectivoTotalImputacionReportUseCaseImpl
+    participant LectivoTotalImputacionClient
+    participant LectivoClient
     participant Adapters as "Feign Adapters"
     participant CoreService as "Core Services"
 
@@ -53,4 +58,19 @@ sequenceDiagram
     GeneratePlanillaDetalleVerticalUseCase-->>-ChequerasReportService: Reporte Excel generado
     ChequerasReportService-->>-ChequerasReportController: ResponseEntity<Resource>
     ChequerasReportController-->>-User: ResponseEntity<Resource>
+
+    User->>+ContableReportController: GET /api/tesoreria/report/contable/planilla/lectivo/{lectivoId}
+    ContableReportController->>+ContableReportService: generateReport()
+    ContableReportService->>+GenerateLectivoTotalImputacionReportUseCaseImpl: generateReport()
+    GenerateLectivoTotalImputacionReportUseCaseImpl->>+LectivoTotalImputacionClient: findAllByLectivo()
+    LectivoTotalImputacionClient->>+CoreService: GET /api/tesoreria/core/lectivototalimputacion/lectivo/{lectivoId}
+    CoreService-->>-LectivoTotalImputacionClient: Lista de LectivoTotalImputacionDto
+    LectivoTotalImputacionClient-->>-GenerateLectivoTotalImputacionReportUseCaseImpl: Lista de LectivoTotalImputacionDto
+    GenerateLectivoTotalImputacionReportUseCaseImpl->>+LectivoClient: findByLectivoId()
+    LectivoClient->>+CoreService: GET /api/tesoreria/core/lectivo/{lectivoId}
+    CoreService-->>-LectivoClient: Datos del lectivo
+    Note over GenerateLectivoTotalImputacionReportUseCaseImpl: Genera Excel con columnas:<br/>Facultad, Tipo Chequera, Geográfica,<br/>Producto, Cuenta Contable, Nombre Cuenta
+    GenerateLectivoTotalImputacionReportUseCaseImpl-->>-ContableReportService: filename del reporte
+    ContableReportService-->>-ContableReportController: filename
+    ContableReportController-->>-User: ResponseEntity<Resource>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.report</artifactId>
-    <version>0.10.1</version>
+    <version>0.11.0</version>
     <name>UM.tesoreria.report-service</name>
     <description>Spring Boot Report Service</description>
     <properties>

--- a/src/main/java/um/tesoreria/report/configuration/ReportConfiguration.java
+++ b/src/main/java/um/tesoreria/report/configuration/ReportConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 
 @Configuration
-@EnableFeignClients(basePackages = "um.tesoreria.report.hexagonal.chequeras.infrastructure.client")
+@EnableFeignClients(basePackages = "um.tesoreria.report.hexagonal")
 @PropertySource("classpath:config/reports.properties")
 public class ReportConfiguration {
 

--- a/src/main/java/um/tesoreria/report/hexagonal/contable/application/service/ContableReportService.java
+++ b/src/main/java/um/tesoreria/report/hexagonal/contable/application/service/ContableReportService.java
@@ -1,0 +1,16 @@
+package um.tesoreria.report.hexagonal.contable.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import um.tesoreria.report.hexagonal.contable.domain.ports.in.GenerateLectivoTotalImputacionReportUseCase;
+
+@Service
+@RequiredArgsConstructor
+public class ContableReportService {
+
+    private final GenerateLectivoTotalImputacionReportUseCase generateLectivoTotalImputacionReportUseCase;
+
+    public String generateReport(Integer lectivoId) {
+        return generateLectivoTotalImputacionReportUseCase.generateReport(lectivoId);
+    }
+}

--- a/src/main/java/um/tesoreria/report/hexagonal/contable/application/usecases/GenerateLectivoTotalImputacionReportUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/report/hexagonal/contable/application/usecases/GenerateLectivoTotalImputacionReportUseCaseImpl.java
@@ -1,0 +1,148 @@
+package um.tesoreria.report.hexagonal.contable.application.usecases;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+import um.tesoreria.report.hexagonal.chequeras.domain.ports.out.LectivoRepository;
+import um.tesoreria.report.hexagonal.contable.domain.model.LectivoTotalImputacion;
+import um.tesoreria.report.hexagonal.contable.domain.ports.in.GenerateLectivoTotalImputacionReportUseCase;
+import um.tesoreria.report.hexagonal.contable.domain.ports.out.LectivoTotalImputacionRepository;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.text.MessageFormat;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class GenerateLectivoTotalImputacionReportUseCaseImpl implements GenerateLectivoTotalImputacionReportUseCase {
+
+    private final Environment environment;
+    private final LectivoTotalImputacionRepository repository;
+    private final LectivoRepository lectivoRepository;
+
+    @Override
+    public String generateReport(Integer lectivoId) {
+        log.debug("Processing GenerateLectivoTotalImputacionReportUseCaseImpl.generateReport for lectivoId: {}", lectivoId);
+        String path = environment.getProperty("path.reports");
+
+        String filename = path + MessageFormat.format("lectivototalimputacion.{0}.xlsx", String.valueOf(lectivoId));
+
+        Workbook book = new XSSFWorkbook();
+        CellStyle styleNormal = book.createCellStyle();
+        Font fontNormal = book.createFont();
+        fontNormal.setBold(false);
+        styleNormal.setFont(fontNormal);
+
+        CellStyle styleBold = book.createCellStyle();
+        Font fontBold = book.createFont();
+        fontBold.setBold(true);
+        styleBold.setFont(fontBold);
+
+        String sheetName = "Imputaciones";
+        try {
+            var lectivo = lectivoRepository.findByLectivoId(lectivoId);
+            if (lectivo != null && lectivo.getNombre() != null) {
+                sheetName = lectivo.getNombre();
+            }
+        } catch (Exception e) {
+            log.warn("Could not retrieve lectivo details for sheet name fallback to default", e);
+        }
+
+        Sheet sheet = book.createSheet(sheetName);
+        Row headerRow = sheet.createRow(0);
+        setCellString(headerRow, 0, "Facultad", styleBold);
+        setCellString(headerRow, 1, "Tipo Chequera", styleBold);
+        setCellString(headerRow, 2, "Geográfica", styleBold);
+        setCellString(headerRow, 3, "Producto", styleBold);
+        setCellString(headerRow, 4, "Cuenta Contable", styleBold);
+        setCellString(headerRow, 5, "Nombre Cuenta", styleBold);
+
+        List<LectivoTotalImputacion> imputaciones = repository.findAllByLectivo(lectivoId);
+
+        int rowIndex = 1;
+        for (LectivoTotalImputacion item : imputaciones) {
+            Row row = sheet.createRow(rowIndex++);
+
+            String facultadVal = "";
+            if (item.getFacultad() != null && item.getFacultad().getNombre() != null) {
+                facultadVal = item.getFacultad().getNombre();
+            } else if (item.getFacultadId() != null) {
+                facultadVal = String.valueOf(item.getFacultadId());
+            }
+
+            String tipoChequeraVal = "";
+            if (item.getTipoChequera() != null && item.getTipoChequera().getNombre() != null) {
+                tipoChequeraVal = item.getTipoChequera().getNombre();
+            } else if (item.getTipoChequeraId() != null) {
+                tipoChequeraVal = String.valueOf(item.getTipoChequeraId());
+            }
+
+            String geograficaVal = "";
+            if (item.getTipoChequera() != null) {
+                if (item.getTipoChequera().getGeografica() != null && item.getTipoChequera().getGeografica().getNombre() != null) {
+                    geograficaVal = item.getTipoChequera().getGeografica().getNombre();
+                } else if (item.getTipoChequera().getGeograficaId() != null) {
+                    geograficaVal = String.valueOf(item.getTipoChequera().getGeograficaId());
+                }
+            }
+
+            String productoVal = "";
+            if (item.getProducto() != null && item.getProducto().getNombre() != null) {
+                productoVal = item.getProducto().getNombre();
+            } else if (item.getProductoId() != null) {
+                productoVal = String.valueOf(item.getProductoId());
+            }
+
+            String cuentaContableVal = "";
+            if (item.getNumeroCuenta() != null) {
+                cuentaContableVal = item.getNumeroCuenta().toPlainString();
+            }
+
+            String nombreCuentaVal = "";
+            if (item.getCuenta() != null && item.getCuenta().getNombre() != null) {
+                nombreCuentaVal = item.getCuenta().getNombre();
+            }
+
+            setCellString(row, 0, facultadVal, styleNormal);
+            setCellString(row, 1, tipoChequeraVal, styleNormal);
+            setCellString(row, 2, geograficaVal, styleNormal);
+            setCellString(row, 3, productoVal, styleNormal);
+            setCellString(row, 4, cuentaContableVal, styleNormal);
+            setCellString(row, 5, nombreCuentaVal, styleNormal);
+        }
+
+        // Auto size columns
+        for (int i = 0; i < 6; i++) {
+            sheet.autoSizeColumn(i);
+        }
+
+        try {
+            File file = new File(filename);
+            // Ensure parent directories exist
+            File parent = file.getParentFile();
+            if (parent != null && !parent.exists()) {
+                parent.mkdirs();
+            }
+            try (FileOutputStream output = new FileOutputStream(file)) {
+                book.write(output);
+                output.flush();
+            }
+            book.close();
+        } catch (Exception e) {
+            log.error("Error writing Excel report for LectivoTotalImputacion", e);
+        }
+
+        return filename;
+    }
+
+    private void setCellString(Row row, int column, String value, CellStyle style) {
+        Cell cell = row.createCell(column);
+        cell.setCellValue(value);
+        cell.setCellStyle(style);
+    }
+}

--- a/src/main/java/um/tesoreria/report/hexagonal/contable/domain/model/Cuenta.java
+++ b/src/main/java/um/tesoreria/report/hexagonal/contable/domain/model/Cuenta.java
@@ -1,0 +1,15 @@
+package um.tesoreria.report.hexagonal.contable.domain.model;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Cuenta {
+    private BigDecimal numeroCuenta;
+    private String nombre;
+}

--- a/src/main/java/um/tesoreria/report/hexagonal/contable/domain/model/LectivoTotalImputacion.java
+++ b/src/main/java/um/tesoreria/report/hexagonal/contable/domain/model/LectivoTotalImputacion.java
@@ -1,0 +1,29 @@
+package um.tesoreria.report.hexagonal.contable.domain.model;
+
+import lombok.*;
+import um.tesoreria.report.hexagonal.chequeras.domain.model.Facultad;
+import um.tesoreria.report.hexagonal.chequeras.domain.model.Lectivo;
+import um.tesoreria.report.hexagonal.chequeras.domain.model.Producto;
+import um.tesoreria.report.hexagonal.chequeras.domain.model.TipoChequera;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LectivoTotalImputacion {
+    private Long lectivoTotalImputacionId;
+    private Integer facultadId;
+    private Integer lectivoId;
+    private Integer tipoChequeraId;
+    private Integer productoId;
+    private BigDecimal numeroCuenta;
+
+    private Facultad facultad;
+    private Lectivo lectivo;
+    private TipoChequera tipoChequera;
+    private Producto producto;
+    private Cuenta cuenta;
+}

--- a/src/main/java/um/tesoreria/report/hexagonal/contable/domain/ports/in/GenerateLectivoTotalImputacionReportUseCase.java
+++ b/src/main/java/um/tesoreria/report/hexagonal/contable/domain/ports/in/GenerateLectivoTotalImputacionReportUseCase.java
@@ -1,0 +1,5 @@
+package um.tesoreria.report.hexagonal.contable.domain.ports.in;
+
+public interface GenerateLectivoTotalImputacionReportUseCase {
+    String generateReport(Integer lectivoId);
+}

--- a/src/main/java/um/tesoreria/report/hexagonal/contable/domain/ports/out/LectivoTotalImputacionRepository.java
+++ b/src/main/java/um/tesoreria/report/hexagonal/contable/domain/ports/out/LectivoTotalImputacionRepository.java
@@ -1,0 +1,9 @@
+package um.tesoreria.report.hexagonal.contable.domain.ports.out;
+
+import um.tesoreria.report.hexagonal.contable.domain.model.LectivoTotalImputacion;
+
+import java.util.List;
+
+public interface LectivoTotalImputacionRepository {
+    List<LectivoTotalImputacion> findAllByLectivo(Integer lectivoId);
+}

--- a/src/main/java/um/tesoreria/report/hexagonal/contable/infrastructure/client/LectivoTotalImputacionClient.java
+++ b/src/main/java/um/tesoreria/report/hexagonal/contable/infrastructure/client/LectivoTotalImputacionClient.java
@@ -1,0 +1,16 @@
+package um.tesoreria.report.hexagonal.contable.infrastructure.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import um.tesoreria.report.hexagonal.contable.infrastructure.client.dto.LectivoTotalImputacionDto;
+
+import java.util.List;
+
+@FeignClient(name = "tesoreria-core-service", contextId = "lectivoTotalImputacionClient", path = "/api/tesoreria/core/lectivototalimputacion")
+public interface LectivoTotalImputacionClient {
+
+    @GetMapping("/lectivo/{lectivoId}")
+    List<LectivoTotalImputacionDto> findAllByLectivo(@PathVariable("lectivoId") Integer lectivoId);
+
+}

--- a/src/main/java/um/tesoreria/report/hexagonal/contable/infrastructure/client/adapter/FeignLectivoTotalImputacionRepositoryAdapter.java
+++ b/src/main/java/um/tesoreria/report/hexagonal/contable/infrastructure/client/adapter/FeignLectivoTotalImputacionRepositoryAdapter.java
@@ -1,0 +1,32 @@
+package um.tesoreria.report.hexagonal.contable.infrastructure.client.adapter;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import um.tesoreria.report.hexagonal.contable.infrastructure.client.dto.LectivoTotalImputacionDto;
+import um.tesoreria.report.hexagonal.contable.domain.model.LectivoTotalImputacion;
+import um.tesoreria.report.hexagonal.contable.domain.ports.out.LectivoTotalImputacionRepository;
+import um.tesoreria.report.hexagonal.contable.infrastructure.client.LectivoTotalImputacionClient;
+import um.tesoreria.report.hexagonal.contable.infrastructure.client.mapper.ContableMapper;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class FeignLectivoTotalImputacionRepositoryAdapter implements LectivoTotalImputacionRepository {
+
+    private final LectivoTotalImputacionClient client;
+    private final ContableMapper mapper;
+
+    @Override
+    public List<LectivoTotalImputacion> findAllByLectivo(Integer lectivoId) {
+        List<LectivoTotalImputacionDto> dtos = client.findAllByLectivo(lectivoId);
+        if (dtos == null) {
+            return Collections.emptyList();
+        }
+        return dtos.stream()
+                .map(dto -> mapper.toDomain(dto))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/um/tesoreria/report/hexagonal/contable/infrastructure/client/dto/CuentaDto.java
+++ b/src/main/java/um/tesoreria/report/hexagonal/contable/infrastructure/client/dto/CuentaDto.java
@@ -1,0 +1,10 @@
+package um.tesoreria.report.hexagonal.contable.infrastructure.client.dto;
+
+import lombok.Data;
+import java.math.BigDecimal;
+
+@Data
+public class CuentaDto {
+    private BigDecimal numeroCuenta;
+    private String nombre = "";
+}

--- a/src/main/java/um/tesoreria/report/hexagonal/contable/infrastructure/client/dto/LectivoTotalImputacionDto.java
+++ b/src/main/java/um/tesoreria/report/hexagonal/contable/infrastructure/client/dto/LectivoTotalImputacionDto.java
@@ -1,0 +1,25 @@
+package um.tesoreria.report.hexagonal.contable.infrastructure.client.dto;
+
+import lombok.Data;
+import um.tesoreria.report.hexagonal.chequeras.infrastructure.client.dto.FacultadDto;
+import um.tesoreria.report.hexagonal.chequeras.infrastructure.client.dto.LectivoDto;
+import um.tesoreria.report.hexagonal.chequeras.infrastructure.client.dto.ProductoDto;
+import um.tesoreria.report.hexagonal.chequeras.infrastructure.client.dto.TipoChequeraDto;
+
+import java.math.BigDecimal;
+
+@Data
+public class LectivoTotalImputacionDto {
+    private Long lectivoTotalImputacionId;
+    private Integer facultadId;
+    private Integer lectivoId;
+    private Integer tipoChequeraId;
+    private Integer productoId;
+    private BigDecimal numeroCuenta;
+
+    private FacultadDto facultad;
+    private LectivoDto lectivo;
+    private TipoChequeraDto tipoChequera;
+    private ProductoDto producto;
+    private CuentaDto cuenta;
+}

--- a/src/main/java/um/tesoreria/report/hexagonal/contable/infrastructure/client/mapper/ContableMapper.java
+++ b/src/main/java/um/tesoreria/report/hexagonal/contable/infrastructure/client/mapper/ContableMapper.java
@@ -1,0 +1,41 @@
+package um.tesoreria.report.hexagonal.contable.infrastructure.client.mapper;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import um.tesoreria.report.hexagonal.chequeras.infrastructure.client.mapper.ChequerasMapper;
+import um.tesoreria.report.hexagonal.contable.domain.model.Cuenta;
+import um.tesoreria.report.hexagonal.contable.domain.model.LectivoTotalImputacion;
+import um.tesoreria.report.hexagonal.contable.infrastructure.client.dto.CuentaDto;
+import um.tesoreria.report.hexagonal.contable.infrastructure.client.dto.LectivoTotalImputacionDto;
+
+@Component
+@RequiredArgsConstructor
+public class ContableMapper {
+
+    private final ChequerasMapper chequerasMapper;
+
+    public Cuenta toDomain(CuentaDto dto) {
+        if (dto == null) return null;
+        return Cuenta.builder()
+                .numeroCuenta(dto.getNumeroCuenta())
+                .nombre(dto.getNombre())
+                .build();
+    }
+
+    public LectivoTotalImputacion toDomain(LectivoTotalImputacionDto dto) {
+        if (dto == null) return null;
+        return LectivoTotalImputacion.builder()
+                .lectivoTotalImputacionId(dto.getLectivoTotalImputacionId())
+                .facultadId(dto.getFacultadId())
+                .lectivoId(dto.getLectivoId())
+                .tipoChequeraId(dto.getTipoChequeraId())
+                .productoId(dto.getProductoId())
+                .numeroCuenta(dto.getNumeroCuenta())
+                .facultad(chequerasMapper.toDomain(dto.getFacultad()))
+                .lectivo(chequerasMapper.toDomain(dto.getLectivo()))
+                .tipoChequera(chequerasMapper.toDomain(dto.getTipoChequera()))
+                .producto(chequerasMapper.toDomain(dto.getProducto()))
+                .cuenta(toDomain(dto.getCuenta()))
+                .build();
+    }
+}

--- a/src/main/java/um/tesoreria/report/hexagonal/contable/infrastructure/web/controller/ContableReportController.java
+++ b/src/main/java/um/tesoreria/report/hexagonal/contable/infrastructure/web/controller/ContableReportController.java
@@ -1,0 +1,31 @@
+package um.tesoreria.report.hexagonal.contable.infrastructure.web.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import um.tesoreria.report.hexagonal.contable.application.service.ContableReportService;
+
+import java.io.FileNotFoundException;
+
+import static um.tesoreria.report.util.Tool.generateFile;
+
+@RestController
+@RequestMapping("/api/tesoreria/report/contable")
+@RequiredArgsConstructor
+@Slf4j
+public class ContableReportController {
+
+    private final ContableReportService service;
+
+    @GetMapping("/planilla/lectivo/{lectivoId}")
+    public ResponseEntity<Resource> generateReport(@PathVariable Integer lectivoId) throws FileNotFoundException {
+        log.debug("Processing ContableReportController.generateReport for lectivoId: {}", lectivoId);
+        String filename = service.generateReport(lectivoId);
+        return generateFile(filename, "planilla_imputacion_" + lectivoId + ".xlsx");
+    }
+}


### PR DESCRIPTION
Closes #65

## Descripción
Nuevo módulo contable con arquitectura hexagonal para generar la planilla de "Lectivo Total Imputación". Se agrega un endpoint REST que genera un reporte Excel con las imputaciones contables agrupadas por facultad, tipo chequera, geográfica, producto y cuenta contable.

## Cambios Realizados
- **feat:** Nuevo modelo de dominio `Cuenta` y `LectivoTotalImputacion`
- **feat:** Nuevo puerto de entrada `GenerateLectivoTotalImputacionReportUseCase`
- **feat:** Nuevo puerto de salida `LectivoTotalImputacionRepository`
- **feat:** Implementación del caso de uso con generación de Excel (Apache POI)
- **feat:** Cliente Feign `LectivoTotalImputacionClient` y adaptador `FeignLectivoTotalImputacionRepositoryAdapter`
- **feat:** DTOs (`CuentaDto`, `LectivoTotalImputacionDto`) y mapper (`ContableMapper`)
- **feat:** Controlador REST `ContableReportController` con endpoint `GET /planilla/lectivo/{lectivoId}`
- **chore:** Ampliado escaneo de `@EnableFeignClients` a todo el paquete hexagonal
- **docs:** Actualizados `CHANGELOG.md`, `README.md` y diagramas Mermaid de arquitectura

## Verificación
- [x] Compilación del proyecto con `mvn clean compile`
- [x] Prueba de generación de reporte Excel
- [x] Integración con `tesoreria-core-service` vía Feign Client
- [x] Documentación actualizada y diagramas consistentes
